### PR TITLE
Delete records for group submissions when deleting submission

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1208,7 +1208,9 @@ class edusign {
             return false;
         }
 
-        if ($this->get_instance()->teamsubmission) {
+        $teamsubmission = $this->get_instance()->teamsubmission;
+
+        if ($teamsubmission == '1') {
             $submission = $this->get_group_submission($userid, 0, false);
         } else {
             $submission = $this->get_user_submission($userid, false);
@@ -1222,7 +1224,7 @@ class edusign {
         $plugins = $this->get_submission_plugins();
         foreach ($plugins as $plugin) {
             if ($plugin->is_enabled() && $plugin->is_visible()) {
-                $plugin->remove($submission);
+                $plugin->remove($submission, $teamsubmission);
             }
         }
         $submission->status = EDUSIGN_SUBMISSION_STATUS_REOPENED;

--- a/submission/signing/locallib.php
+++ b/submission/signing/locallib.php
@@ -604,7 +604,26 @@ class edusign_submission_signing extends edusign_submission_plugin {
         global $DB;
         $DB->delete_records('edusignsubmission_signing', array('submission' => $submission->id ));
         $submission->status = EDUSIGN_SUBMISSION_STATUS_NEW;
+        
+        // Delete record for single users.
         $DB->delete_records('edusign_submission', array('id' => $submission->id));
+
+        // Delete records for groups #22.
+        if ($teamsubmission == '1') {
+            
+            // Delete group submission.
+            $DB->delete_records('edusign_submission', 
+                array('edusignment' => $submission->edusignment, 'groupid' => $submission->groupid));        
+            
+            // Delete user submissions.
+            $members = groups_get_members($submission->groupid);
+            foreach ($members as $member) {
+                $DB->delete_records('edusign_submission', 
+                    array('edusignment' => $submission->edusignment, 'groupid' => '0', 'userid' => $member->id));        
+            }
+            
+        }
+
         return true;
     }
     


### PR DESCRIPTION
Beim normalen assign plugin wird nur der Status von submissions umgesetzt - bei diesem Plugin werden tatsächlich die DB records gelöscht.

Das ist bei group submissions ein wenig schwierig, weil da recht viele einzelne records angelegt werden - für jeden user, und für die group.

Beim Löschens einer Group submission auf der UI werden jetzt alle diese records gelöscht.